### PR TITLE
Adding support for vsixgallery.com

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,13 @@ build:
   project: TidyTabs.sln
   verbosity: minimal
 
-artifacts:
-  - path: TidyTabs\bin\Release\TidyTabs.vsix
+install:
+  - ps: (new-object Net.WebClient).DownloadString("https://raw.github.com/madskristensen/ExtensionScripts/master/AppVeyor/vsix.ps1") | iex
+
+before_build: 
+  # Increment version in .vsixmanifest and update the AppVeyor build version to match
+  - ps: Vsix-IncrementVsixVersion | Vsix-UpdateBuildVersion
+
+after_test:
+  # Push artifacts and publish the nighly build to http://vsixgallery.com
+  - ps: Vsix-PushArtifacts | Vsix-PublishToGallery


### PR DESCRIPTION
This change will do a few cool things;

1. Increment the version in the .vsixmanifest file automatically
2. Update the AppVeyor build version to match
3. Push artifacts without the full path in the link and with a nice description 
4. Upload the compiled .vsix file to vsixgallery.com