### PR TITLE
Refactored versioning

### DIFF
--- a/TidyTabs/Properties/AssemblyInfo.cs
+++ b/TidyTabs/Properties/AssemblyInfo.cs
@@ -11,6 +11,7 @@ using System;
 using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
+using DaveMcKeown.TidyTabs;
 
 [assembly: AssemblyTitle("Tidy Tabs")]
 [assembly: AssemblyDescription("Tidy Tabs Visual Studio extension")]
@@ -30,5 +31,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(false)]
 [assembly: NeutralResourcesLanguage("en-US")]
-[assembly: AssemblyVersion("1.9.4")]
-[assembly: AssemblyFileVersion("1.9.4")]
+[assembly: AssemblyVersion(TidyTabsPackage.Version)]
+[assembly: AssemblyFileVersion(TidyTabsPackage.Version)]

--- a/TidyTabs/TidyTabsPackage.cs
+++ b/TidyTabs/TidyTabsPackage.cs
@@ -32,13 +32,14 @@ namespace DaveMcKeown.TidyTabs
     /// </summary>
     [ProvideOptionPage(typeof(TidyTabsOptionPage), "Tidy Tabs", "Options", 1000, 1001, false)]
     [PackageRegistration(UseManagedResourcesOnly = true)]
-    [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
+    [InstalledProductRegistration("#110", "#112", Version, IconResourceID = 400)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideAutoLoad(UIContextGuids80.SolutionExists)]
     [Guid(GuidList.guidTidyTabsPkgString)]
     [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1126:PrefixCallsCorrectly", Justification = "Reviewed")]
     public sealed class TidyTabsPackage : Package, IVsBroadcastMessageEvents, IDisposable
     {
+        public const string Version = "1.9.4";
         /// <summary>
         ///     A lock object for document purge operations
         /// </summary>


### PR DESCRIPTION
Added a simpler way to handle versioning.

1. Put the version in the `TidyTabsPackage.cs` file
2. Link to it from the package attributes so it shows up correctly in Help -> About
3. Updated `AssemblyInfo` to pull the version from the package file

This is just a refactoring that makes version handling easier