### PR TITLE
**Changed:** VSIX Manifest file to allow Extension to run in Visual Studio 2019.

### DIFF
--- a/TidyTabs/source.extension.vsixmanifest
+++ b/TidyTabs/source.extension.vsixmanifest
@@ -15,9 +15,9 @@
     <Tags>tabs, visual studio, coding</Tags>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[11.0,16.0)" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[11.0,17.0)" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
   </Dependencies>
@@ -26,6 +26,6 @@
            Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Microsoft.VisualStudio.Component.CoreEditor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Microsoft.VisualStudio.Component.CoreEditor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
I've had a look into this one and I believe these changes should allow the Extension to be installed for Visual Studio 2019.

Comment on original Issue: [#18 - Update Visual Studio Marketplace Support](https://github.com/davemckeown/TidyTabs-VisualStudio/issues/18#issuecomment-449015695)

This involved some minor updates to the Manifest file to allow later Versions of Visual Studio and also updated the Version Range for the 'Microsoft.VisualStudio.Component.CoreEditor' prerequisite.

Hope this helps!